### PR TITLE
Fix  $DOCKER_XENFORO_PHP_EXT_INSTALL empty

### DIFF
--- a/php-apache/build.sh
+++ b/php-apache/build.sh
@@ -41,7 +41,11 @@ esac
 export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS"
 
 docker-php-source extract
-eval "docker-php-ext-install $DOCKER_XENFORO_PHP_EXT_INSTALL"
+
+if [$DOCKER_XENFORO_PHP_EXT_INSTALL]
+  then eval "docker-php-ext-install $DOCKER_XENFORO_PHP_EXT_INSTALL"
+fi
+
 eval "pecl install imagick $DOCKER_XENFORO_PHP_PECL_INSTALL"
 eval "docker-php-ext-enable imagick $DOCKER_XENFORO_PHP_PECL_INSTALL"
 /tmp/build_apache.sh


### PR DESCRIPTION
Error message:

```
usage: /usr/local/bin/docker-php-ext-install [-jN] ext-name [ext-name ...]
   ie: /usr/local/bin/docker-php-ext-install gd mysqli
       /usr/local/bin/docker-php-ext-install pdo pdo_mysql
       /usr/local/bin/docker-php-ext-install -j5 gd mbstring mysqli pdo pdo_mysql shmop

if custom ./configure arguments are necessary, see docker-php-ext-configure

Possible values for ext-name:
bcmath bz2 calendar ctype curl dba dom enchant exif fileinfo filter ftp gd gettext gmp hash iconv imap interbase intl json ldap mbstring mysqli oci8 odbc opcache pcntl pdo pdo_dblib pdo_firebird pdo_mysql pdo_oci pdo_odbc pdo_pgsql pdo_sqlite pgsql phar posix pspell readline recode reflection session shmop simplexml snmp soap sockets sodium spl standard sysvmsg sysvsem sysvshm tidy tokenizer wddx xml xmlreader xmlrpc xmlwriter xsl zend_test zip

Some of the above modules are already compiled into PHP; please check
the output of "php -i" to see which modules are already loaded.
```